### PR TITLE
Vsix packaging not happening, out folder has main.js not extension.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "onFileSystem:im",
     "onStartupFinished"
   ],
-  "main": "./out/extension.js",
+  "main": "./out/main.js",
   "contributes": {
     "snippets": [
       {


### PR DESCRIPTION
Vsix packaging not happening, out folder has main.js not extension.js because esbuild has --outfile=out/main.js 
