### PR TITLE
Version 2.5.1 - Minor updates to ensure multi-server support compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,8 +194,8 @@ Updates:
 
 - To allow for multi-server support, the active NSP server, the port, and connection details (user/pass) have been moved to workspace settings (window scope instead of application scope). This allows for different workspaces to connect to different NSP servers.
 
-- Implemented a command function nokia-wfm.connect (Provides support for NSP-Connect extension):
+- Implemented a command function nokia-intent-manager.connect (Provides support for NSP-Connect extension):
 
 - The command can be called by other extensions (NSP-connect - not released yet) to connect to the NSP server using certain credentials specified by the NSP-connect extension.
 
-- This does not affect the current functionality of the WFM extension.
+- This does not affect the current functionality of the IM extension.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,9 +190,12 @@ Updates:
 
 ## [2.5.1]
 
-- Settings have been moved to workspace settings rather than global user settings.
-- To allow for multi-server support, the active nsp Server, the port, and connection details has been moved to workspace settings: (window scope instead of application scope). This allows for different workspaces to connect to different NSP servers.
+- Certain settings have been moved to workspace settings rather than global user settings.
+
+- To allow for multi-server support, the active NSP server, the port, and connection details (user/pass) have been moved to workspace settings (window scope instead of application scope). This allows for different workspaces to connect to different NSP servers.
 
 - Implemented a command function nokia-wfm.connect (Provides support for NSP-Connect extension):
+
 - The command can be called by other extensions (NSP-connect - not released yet) to connect to the NSP server using certain credentials specified by the NSP-connect extension.
-- This does no affect the current functionality of the WFM extension.
+
+- This does not affect the current functionality of the WFM extension.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,3 +187,12 @@ Updates:
 * Show NSP version as {major}.{minor}. With this "24.4.0" is displayed now as "24.4".
 * New IPL!nk template for next-gen JavaScript engine (GraalJS)
 * Hide empty tabs in audit report
+
+## [2.5.1]
+
+- Settings have been moved to workspace settings rather than global user settings.
+- To allow for multi-server support, the active nsp Server, the port, and connection details has been moved to workspace settings: (window scope instead of application scope). This allows for different workspaces to connect to different NSP servers.
+
+- Implemented a command function nokia-wfm.connect (Provides support for NSP-Connect extension):
+- The command can be called by other extensions (NSP-connect - not released yet) to connect to the NSP server using certain credentials specified by the NSP-connect extension.
+- This does no affect the current functionality of the WFM extension.

--- a/README.md
+++ b/README.md
@@ -90,19 +90,37 @@ To compile and generate the VSIX for installation, run:
 
     vsce package
 
-## Extension Settings
+## Extension Settings and Usage
 
-To make the extension work, make sure you configure the following attributes in the extension settings:
+### General Settings 
 
-![vsCode extension settings](https://raw.githubusercontent.com/nokia/vscode-intent-manager/main/media/ExtensionSettings.png)
+To configure the extension, you need to configure the following attributes in VsCode Extension Settings.
+
+```
+ctrl+shift+p > Preferences: Open Settings > Extensions > Workflow Manager
+```
+
+* `Intent Manager > Parallel Operations: Enable`: Improve performance by running things in-parallel (EXPERIMENTAL)
+* `Intent Manager: Timeout`: Client-side timeout for NSP API calls
+* `Intent Manager: Ignore Labels`: Hide intent-types from the user based on labels (helps to focus)
+
+### Connect to NSP IM
+
+To connect to an NSP IM, you need to configure the following attributes in VsCode **workspace** settings:
+
+```
+ctrl+shift+p > Preferences: Open Workspace Settings > Extensions > Workflow Manager
+```
+
 
 * `Intent Manager: NSPIP`: IP-address or hostname of the NSP server
 * `Intent Manager: User`: NSP username to be used
 * `Intent Manager: Password`: NSP password to be used (password is hidden, using vsCode secrets)
-* `Intent Manager: Timeout`: Client-side timeout for NSP API calls
-* `Intent Manager: Ignore Labels`: Hide intent-types from the user based on labels (helps to focus)
 * `Intent Manager: Port`: Usage of port 443 is recommended
-* `Intent Manager > Parallel Operations: Enable`: Improve performance by running things in-parallel (EXPERIMENTAL)
+
+
+
+
 
 ## Release Notes
 

--- a/build_vsix.py
+++ b/build_vsix.py
@@ -1,0 +1,36 @@
+import os
+import time
+
+def main():
+    
+    # Cd to the directory of the script
+    os.chdir(os.path.dirname(os.path.realpath(__file__)))
+    
+    # uninstall the old version
+    os.system("code --uninstall-extension *.vsix")
+
+    # delete the old vsix file
+    os.system("rm -rf *.vsix")
+
+    # compile the extension
+    os.system("npm run compile")
+    
+    # change npm version to 18
+    os.system("nvm use node")
+    time.sleep(1) # wait for npm version to update
+    os.system("npm -v")
+    os.system("npm install -g typescript")
+    os.system("npm install -g @vscode/vsce")
+    os.system("npm list -g")
+    os.system("npm install . ")
+    os.system("npm list")
+    os.system("vsce package")
+
+    # Install the vsix file
+    os.system("code --install-extension *.vsix")
+
+    # Intstall the
+if __name__ == "__main__":
+    main()
+
+# Run the script> python3 build_vsix.py

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nokia-intent-manager",
   "displayName": "NOKIA_IM",
   "description": "NOKIA IM vsCode Developer Plugin",
-  "version": "2.5.0",
+  "version": "2.5.0", 
   "icon": "media/NSP_Logo.png",
   "publisher": "Nokia",
   "repository": "http://github.com/nokia/vscode-intent-manager",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nokia-intent-manager",
   "displayName": "NOKIA_IM",
   "description": "NOKIA IM vsCode Developer Plugin",
-  "version": "2.5.0", 
+  "version": "2.5.1", 
   "icon": "media/NSP_Logo.png",
   "publisher": "Nokia",
   "repository": "http://github.com/nokia/vscode-intent-manager",
@@ -239,7 +239,8 @@
           "scope": "window",
           "enum": [
             "443",
-            "8545"
+            "8545",
+            "8547"
           ],
           "enumDescriptions": [
             "443 port enabled in newer releases of NSP. 8545 to be deprecated.",
@@ -255,7 +256,7 @@
         },
         "intentManager.password": {
           "type": "null",
-          "markdownDescription": "[Set Password]",
+          "markdownDescription": "[Set Password](command:nokia-intent-manager.setPassword)",
           "scope": "window",
           "description": "Intent Manager password"
         },

--- a/package.json
+++ b/package.json
@@ -229,14 +229,14 @@
         "intentManager.NSPIP": {
           "type": "string",
           "default": "localhost",
-          "scope": "application",
+          "scope": "window",
           "format": "ipv4",
           "description": "Intent Manager hostname or IP address"
         },
         "intentManager.port": {
           "type": "string",
           "default": "443",
-          "scope": "application",
+          "scope": "window",
           "enum": [
             "443",
             "8545"
@@ -250,13 +250,13 @@
         "intentManager.user": {
           "type": "string",
           "default": "admin",
-          "scope": "application",
+          "scope": "window",
           "description": "Intent Manager username (default: admin)"
         },
         "intentManager.password": {
           "type": "null",
-          "markdownDescription": "[Set Password](command:nokia-intent-manager.setPassword)",
-          "scope": "application",
+          "markdownDescription": "[Set Password]",
+          "scope": "window",
           "description": "Intent Manager password"
         },
         "intentManager.timeout": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ export function activate(context: vscode.ExtensionContext) {
 		if (password !== undefined)
 			secretStorage.store("nsp_im_password", password);
 	});
-	
+
 	vscode.commands.registerCommand('nokia-intent-manager.connect', async (username: string|undefined, password: string|undefined, nspAddr: string|undefined, port: string) => {
 		const config = vscode.workspace.getConfiguration('intentManager');
 		if (username === undefined) {
@@ -89,6 +89,5 @@ export function activate(context: vscode.ExtensionContext) {
 	const fileAssociations : {[key: string]: string} = vscode.workspace.getConfiguration('files').get('associations') || {};
 	fileAssociations["/*_v*/views/*"] = "json";
 	vscode.workspace.getConfiguration('files').update('associations', fileAssociations);
-
 	vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders.length : 0, null, { uri: vscode.Uri.parse('im:/'), name: "Intent Manager" });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,8 +60,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async (e) => {
 		if (e.affectsConfiguration('intentManager')) {
-			// config has changed
-			imProvider.updateSettings();
+			imProvider.updateSettings(); // config has changed
 		}
 	}));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,26 +30,24 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('nokia-intent-manager.newVersion',       async (...args) => imProvider.newVersion(args)));
 	context.subscriptions.push(vscode.commands.registerCommand('nokia-intent-manager.newIntentType',    async (...args) => imProvider.newIntentTypeFromTemplate(args)));
 	
-	vscode.commands.registerCommand('nokia-intent-manager.connect', async (username: string|undefined, password: string|undefined, nspAddr: string|undefined, standardPort: Boolean) => {
+	vscode.commands.registerCommand('nokia-intent-manager.connect', async (username: string|undefined, password: string|undefined, nspAddr: string|undefined, port: string) => {
 		const config = vscode.workspace.getConfiguration('intentManager');
-		if (username === undefined)
+		if (username === undefined) {
 			username = await vscode.window.showInputBox({title: "Username"});
-		if (username !== undefined)
-			config.update("user", username, vscode.ConfigurationTarget.Workspace);
-		if (password === undefined)
-			password = await vscode.window.showInputBox({password: true, title: "Password"});
-		if (password !== undefined)
-			secretStorage.store("nsp_im_password", password);
-		if (standardPort === true) {
-			config.update("port", "443", vscode.ConfigurationTarget.Workspace);
-		} else {
-			let imPort = await vscode.window.showInputBox({ prompt: 'Enter Port for NSP IM...' });
-			config.update("port", imPort, vscode.ConfigurationTarget.Workspace);
 		}
+		if (username !== undefined) {
+			config.update("user", username, vscode.ConfigurationTarget.Workspace);
+		}
+		if (password === undefined) {
+			password = await vscode.window.showInputBox({password: true, title: "Password"});
+		} else {
+			secretStorage.store("nsp_im_password", password);
+		}
+		config.update("port", port, vscode.ConfigurationTarget.Workspace);
 		config.update("NSPIP", nspAddr, vscode.ConfigurationTarget.Workspace);
 	});
 
-	function updateStatusBarItem(){
+	function updateStatusBarItem() {
 		const editor = vscode.window.activeTextEditor;
 		const sbar = imProvider.getStatusBarItem();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,13 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('nokia-intent-manager.newVersion',       async (...args) => imProvider.newVersion(args)));
 	context.subscriptions.push(vscode.commands.registerCommand('nokia-intent-manager.newIntentType',    async (...args) => imProvider.newIntentTypeFromTemplate(args)));
 	
+	vscode.commands.registerCommand('nokia-intent-manager.setPassword', async (password: string|undefined) => {
+		if (password === undefined)
+			password = await vscode.window.showInputBox({password: true, title: "Password"});
+		if (password !== undefined)
+			secretStorage.store("nsp_im_password", password);
+	});
+	
 	vscode.commands.registerCommand('nokia-intent-manager.connect', async (username: string|undefined, password: string|undefined, nspAddr: string|undefined, port: string) => {
 		const config = vscode.workspace.getConfiguration('intentManager');
 		if (username === undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,11 +30,23 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('nokia-intent-manager.newVersion',       async (...args) => imProvider.newVersion(args)));
 	context.subscriptions.push(vscode.commands.registerCommand('nokia-intent-manager.newIntentType',    async (...args) => imProvider.newIntentTypeFromTemplate(args)));
 	
-	vscode.commands.registerCommand('nokia-intent-manager.setPassword', async (password: string|undefined) => {
+	vscode.commands.registerCommand('nokia-intent-manager.connect', async (username: string|undefined, password: string|undefined, nspAddr: string|undefined, standardPort: Boolean) => {
+		const config = vscode.workspace.getConfiguration('intentManager');
+		if (username === undefined)
+			username = await vscode.window.showInputBox({title: "Username"});
+		if (username !== undefined)
+			config.update("user", username, vscode.ConfigurationTarget.Workspace);
 		if (password === undefined)
 			password = await vscode.window.showInputBox({password: true, title: "Password"});
 		if (password !== undefined)
 			secretStorage.store("nsp_im_password", password);
+		if (standardPort === true) {
+			config.update("port", "443", vscode.ConfigurationTarget.Workspace);
+		} else {
+			let imPort = await vscode.window.showInputBox({ prompt: 'Enter Port for NSP IM...' });
+			config.update("port", imPort, vscode.ConfigurationTarget.Workspace);
+		}
+		config.update("NSPIP", nspAddr, vscode.ConfigurationTarget.Workspace);
 	});
 
 	function updateStatusBarItem(){

--- a/src/providers/IntentManagerProvider.ts
+++ b/src/providers/IntentManagerProvider.ts
@@ -78,7 +78,7 @@ export class IntentManagerProvider implements vscode.FileSystemProvider, vscode.
 	};
 
 	public onDidChangeFileDecorations: vscode.Event<vscode.Uri | vscode.Uri[] | undefined>;
-    private _eventEmiter: vscode.EventEmitter<vscode.Uri | vscode.Uri[]>;
+    private _eventEmiter: vscode.EventEmitter<vscode.Uri | vscode.Uri[]>; // = new vscode.EventEmitter(); it is defined in constructor
 
 	/**
 	 * Create IntentManagerProvider
@@ -190,10 +190,8 @@ export class IntentManagerProvider implements vscode.FileSystemProvider, vscode.
 						setTimeout(() => this._revokeAuthToken(), 600000); // automatically revoke token after 10min
                     } else {
 						this.pluginLogs.warn("NSP response:", response.status, json.error);
-
 						DECORATION_DISCONNECTED.tooltip = "Authentication failure (user:"+this.username+", error:"+json.error+")!";
 						this._eventEmiter.fire(vscode.Uri.parse('im:/'));
-
 						this.authToken = undefined; // Reset authToken on error
                         reject("Authentication Error!");
 					}
@@ -1384,7 +1382,6 @@ export class IntentManagerProvider implements vscode.FileSystemProvider, vscode.
 
 			DECORATION_CONNECTED.tooltip = "Connecting..."; // revert to original text
 			DECORATION_DISCONNECTED.tooltip = "Not connected!"; // revert to original text
-
 			this._eventEmiter.fire(vscode.Uri.parse('im:/'));
 		}	
 

--- a/src/providers/IntentManagerProvider.ts
+++ b/src/providers/IntentManagerProvider.ts
@@ -213,8 +213,7 @@ export class IntentManagerProvider implements vscode.FileSystemProvider, vscode.
 
 	/**
 	 * Gracefully revoke NSP auth-token.
-	 */	
-
+	 */
 	private async _revokeAuthToken(): Promise<void> {
 		if (this.authToken) {
 			const token = await this.authToken;
@@ -261,7 +260,7 @@ export class IntentManagerProvider implements vscode.FileSystemProvider, vscode.
 					"Accept": "application/yang-data+json",
 					"Authorization": "Bearer " + token
 				};
-			else
+			else 
 				options.headers = {
 					'Content-Type': "application/json",
 					'Accept': "application/json",	


### PR DESCRIPTION
- Certain settings have been moved to workspace settings rather than global user settings.

- To allow for multi-server support, the active NSP server, the port, and connection details (user/pass) have been moved to workspace settings (window scope instead of application scope). This allows for different workspaces to connect to different NSP servers.

- Implemented a command function nokia-wfm.connect (Provides support for NSP-Connect extension):

- The command can be called by other extensions (NSP-connect - not released yet) to connect to the NSP server using certain credentials specified by the NSP-connect extension.

- This does not affect the current functionality of the WFM extension.