### PR TITLE
Added Settting option 'includeLabels' to whitelist filter for intent-t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,6 +308,14 @@
           },
           "description": "Intent-types with these labels will be hidden."
         },
+        "intentManager.includeLabels": {
+          "type": "array",
+          "scope": "application",
+          "items": {
+            "type": "string"
+          },
+          "description": "Intent-types with these labels only will be visible."
+        },
         "intentManager.parallelOperations.enable": {
           "type": "boolean",
           "scope": "application",

--- a/src/providers/IntentManagerProvider.ts
+++ b/src/providers/IntentManagerProvider.ts
@@ -53,6 +53,7 @@ export class IntentManagerProvider implements vscode.FileSystemProvider, vscode.
 
 	timeout: number;
 	fileIgnore: Array<string>;
+	fileInclude: Array<string>;
 	parallelOps: boolean;
 
 	serverLogsOffset: string;
@@ -95,6 +96,7 @@ export class IntentManagerProvider implements vscode.FileSystemProvider, vscode.
 
 		this.timeout = config.get("timeout") ?? 90; // default: 1:30min
 		this.fileIgnore = config.get("ignoreLabels") ?? [];
+		this.fileInclude = config.get("includeLabels") ?? [];
 		this.parallelOps = config.get("parallelOperations.enable") ?? false;
 
 		this.serverLogsOffset = config.get("serverLogsOffset") ?? "10m";
@@ -626,6 +628,10 @@ export class IntentManagerProvider implements vscode.FileSystemProvider, vscode.
 			for (const label of this.fileIgnore) {
 				// apply blacklist for label(s) provided in extension settings
 				intentTypes = intentTypes.filter((entry:any) => !entry.label.includes(label));
+			}
+			for (const label of this.fileInclude) {
+				// apply whitelist for label(s) provided in extension settings
+				intentTypes = intentTypes.filter((entry:any) => entry.label.includes(label));
 			}
 			result = intentTypes.map((entry: { name: string; version: string; }) => [entry.name+'_v'+entry.version, vscode.FileType.Directory]);
 
@@ -1466,6 +1472,7 @@ export class IntentManagerProvider implements vscode.FileSystemProvider, vscode.
 
 		this.timeout = config.get("timeout") ?? 90; // default: 1:30min
 		this.fileIgnore = config.get("ignoreLabels") ?? [];
+		this.fileInclude = config.get("includeLabels") ?? [];
 		this.parallelOps = config.get("parallelOperations.enable") ?? false;
 
 		this.serverLogsOffset = config.get("serverLogsOffset") ?? "10m";


### PR DESCRIPTION
Added the Extension Setting "includeLabels" to whitelist Intent-Types based on meta-info.json labels.

This feature is much more useful when working on a NSP being shared by multiple people and we want to reduce the clutter. 

Inorder to isolate a particular Intent-Type that we are concerned about we cannot use excludeLabels since that would mean we have to add something to all the other intents inorder to focus and filter a specific intent-type.

Instead using the includeLabels setting we can add a temporary Label to our own intent and then use it for filtering.