### PR TITLE
template improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,4 +347,16 @@ Fixes:
 Added:
 * Improve fixed intent-type template
 * Improve preview function in MD-CLI format
-* Adding helper deletePath() to allow skipping passwords and hash-values from audits 
+* Adding helper deletePath() to allow skipping passwords and hash-values from audits
+
+## [4.2.2]
+
+Template Improvement (Developer Experience):
+* Abstract/Fixed intent-types: FTL JSON parse diagnostics for extra-long rendered output using multi-arg `logger.error` with at most 10_000 char fragments
+* Rendered output omitted when longer than 5 MB. Only summary line will be generated (OpenSearch / VS Code Server Logs)
+
+Template Refactoring:
+* Quote/style normalization in ICM `IntentHandlerBase.mjs` and abstract `IntentHandler.mjs`
+* Added `unwrapRestconfBody()` for common RESTCONF envelope handling
+* Added `mergePreservedSubtrees()` keeping existing behavior for merging actual config subtrees based on pre-approved misalignments aka ignoreChildren
+* Added `isPreApproved()` keeping existing behavior to ignore additional subtrees in the actual config during audits based on pre-approved misalignments aka ignoreChildren

--- a/templates/common_abstract/common/IntentHandler.mjs
+++ b/templates/common_abstract/common/IntentHandler.mjs
@@ -512,7 +512,7 @@ export class IntentHandler extends WebUI
       return false;
 
     // split addr from prefix-len and validate prefix-len, if present
-    const [addr, prefix] = value.split('/');
+    const [addr, prefix] = value.split("/");
     if (prefix && (!/^\d{1,3}$/.test(prefix) || parseInt(prefix, 10) > 128))
       return false;
 
@@ -563,7 +563,7 @@ export class IntentHandler extends WebUI
     }
 
     // Remove leading zeros from all parts
-    addr = addr.toLowerCase().split(":").map(part => part.replace(/^0+/, '') || '0').join(":");
+    addr = addr.toLowerCase().split(":").map(part => part.replace(/^0+/, "") || "0").join(":");
 
     // Identify the longest zero sequence for "::" compression
     const zeroSequences = addr.match(/(^|:)(0:)+(0$)?/g);
@@ -583,7 +583,7 @@ export class IntentHandler extends WebUI
 
   assertEqual(actual, expected, message) {
     if (actual !== expected) {
-        throw new Error(`❌ Unit Testing Failed: ${message} | Expected: '${expected}', Got: '${actual}'`);
+        throw new Error(`❌ Unit Testing Failed: ${message} | Expected: "${expected}", Got: "${actual}"`);
     } else {
         logger.info(`✅ Passed: ${message}`);
     }
@@ -627,15 +627,104 @@ export class IntentHandler extends WebUI
    */
   
   getListKeys(neId, listPath) {
-     // remove instance identifiers from path:
-    const path = listPath.replace(/=[^/]+/g, '');
+    // remove instance identifiers from path:
+    const path = listPath.replace(/=[^/]+/g, "");
 
     if (!(path in this.mdcKeys)) {
       this.mdcKeys[path] = NSP.mdcListKeys(neId, path);
-      logger.info('list-key cache updated: {}', JSON.stringify(this.mdcKeys));
+      logger.info("list-key cache updated: {}", JSON.stringify(this.mdcKeys));
     }
 
     return this.mdcKeys[path];
+  }
+
+  /**
+   * Unwrap JSON body for intent audits and synchronize operations (merge / replace).
+   * Used for both:
+   *   - intended config (iCfg) — RESTCONF YANG-Patch `replace` request body
+   *   - actual config (aCfg) — RESTCONF `GET` data response body
+   *
+   * The return value is the config root used by recursive `compareConfig` or ignoreChildren merge.
+   *
+   * @param {object} body Single RESTCONF resource object (one module-qualified root key).
+   * @returns {*} Unwrapped root value (typically an object; containers skip step 2).
+   */
+
+  unwrapRestconfBody(body) {
+    // **Step 1:** Peel the outer wrapper: the last path segment appears once as the sole
+    // top-level property name (module-qualified root). Its value is the subtree for the target.
+    //
+    // Example: {"nokia-conf:port": [{"port-id": "1/1/1", ...}]} → [{"port-id": "1/1/1", ...}]
+
+    const config = Object.values(body)[0];
+
+    // **Step 2:** RFC 8040 / RFC 8072 JSON: a single list instance is a one-element array.
+    // Unwrap to the entry object for audits and merge. Empty array → {}.
+    //
+    // Example: [{"port-id": "1/1/1", ...}] → {"port-id": "1/1/1", ...}
+
+    if (Array.isArray(config)) {
+      if (config.length > 0)
+        return config[0];
+      else
+        return {};
+    }
+    return config;
+  }
+
+  /**
+   * Returns if the relativePath belongs to any ignored children. Used as audit helper to avoid
+   * reporting additional subtrees/attributes that are part of pre-approved misalignments.
+   * 
+   * `neId` / `basePath` are currently unused. Added for future enhancements to properly support
+   * instance paths, while method needs to figure out list-keys correctly.
+   *
+   * @param {string} neId              (reserved for future use)
+   * @param {string} basePath          (reserved for future use)
+   * @param {string} relativePath
+   * @param {string[]} ignoreChildren
+   * @returns {boolean}
+   */
+
+  isPreApproved(neId, basePath, relativePath, ignoreChildren) {
+    return (ignoreChildren ?? []).some(path => relativePath.startsWith(path));
+  }
+
+  /**
+   * Merges subtrees from `actualConfig` (GET response) into `desiredConfig` (in-place mutation), to
+   * preserve nodal configuration for pre-approved misalignments (ignoreChildren).
+   * 
+   * `neId` / `deviceModelPath` are currently unused. Added for future enhancements to properly support
+   * instance paths, while method needs to figure out list-keys correctly.
+   *
+   * @param {string} neId              (reserved for future use)
+   * @param {string} deviceModelPath   (reserved for future use)
+   * @param {object} desiredConfig     Configuration request payload body from FTL (operation: replace)
+   * @param {object} actualConfig      Configuration response payload (RESTCONF GET)
+   * @param {string[]} ignoreChildren  Paths to preserve from actual configuration
+   */
+
+  mergePreservedSubtrees(neId, deviceModelPath, desiredConfig, actualConfig, ignoreChildren) {
+    const aCfg = this.unwrapRestconfBody(actualConfig);
+    const iCfg = this.unwrapRestconfBody(desiredConfig);
+    (ignoreChildren ?? []).forEach(path => {
+      const keys = path.split("/");
+      let source = aCfg;
+      let target = iCfg;
+      for (let i = 0; i < keys.length; i++) {
+        const k = keys[i];
+        if (k in source) {
+          if (i < keys.length - 1) {
+            if (!(k in target))
+              target[k] = {};
+            source = source[k];
+            target = target[k];
+          } else {
+            target[k] = source[k];
+          }
+        } else break;
+      }
+    });
   }
 
   /**
@@ -728,33 +817,20 @@ export class IntentHandler extends WebUI
     if (mode !== "merge") {
       for (const key in aCfg) {
         if (!(key in iCfg)) {
-          // Possibility to exclude children (pre-approved misalignments) that match the list provided.
-          // Current Restrictions:
-          //  (1) Intent config (icfg) must not contain attributes that match the ignored children 
-          //  (2) Intent config (icfg) must contain the direct parents of the ignored children
-
-          let found = "";
-          const aKey = path+key;
-          for (const idx in ignore) {
-            if (aKey.startsWith(ignore[idx])) {
-              found = ignore[idx];
-              break;
-            }
-          }
-
-          if (!found) {
+          const relativePath = path + key;
+          if (!this.isPreApproved(neId, basePath, relativePath, ignore)) {
             if (aCfg[key] instanceof Object) {
               // mismatch: undesired list/container
 
               const aVal = JSON.stringify(aCfg[key]);
               if ((aVal === "{}") || (aVal === "[]") || (aVal === "[null]"))
-                auditReport.addMisAlignedAttribute(new MisAlignedAttribute("/"+basePath+"/"+aKey, null, aVal, obj));
+                auditReport.addMisAlignedAttribute(new MisAlignedAttribute("/"+basePath+"/"+relativePath, null, aVal, obj));
               else
                 // undesired object: is-configured=true, is-undesired=default(true)
-                auditReport.addMisAlignedObject(new MisAlignedObject("/"+basePath+"/"+aKey, true, neId, true));
+                auditReport.addMisAlignedObject(new MisAlignedObject("/"+basePath+"/"+relativePath, true, neId, true));
             } else {
               // mismatch: additional leaf
-              auditReport.addMisAlignedAttribute(new MisAlignedAttribute("/"+basePath+"/"+aKey, null, aCfg[key].toString(), obj));
+              auditReport.addMisAlignedAttribute(new MisAlignedAttribute("/"+basePath+"/"+relativePath, null, aCfg[key].toString(), obj));
             }
           }
         }
@@ -811,7 +887,7 @@ export class IntentHandler extends WebUI
                   match = RegExp(iValue).test(aValue[0]);
                   break;
                 default:
-                  throw new Error(`Unsupported match-type '${check}' for path '${path}', value '${iValue}'`);
+                  throw new Error(`Unsupported match-type "${check}" for path "${path}", value "${iValue}"`);
               }
               if (!match)
                 auditReport.addMisAlignedAttribute(new MisAlignedAttribute("/"+qPath+"/"+key, iValue.toString(), aValue[0].toString(), siteName));
@@ -868,7 +944,7 @@ export class IntentHandler extends WebUI
       template = resourceProvider.getResource(templateName);
     } catch (exception) {
       logger.error("Exception reading resource '{}': {}", templateName, exception);
-      throw new Error(`Deploy-template '${templateName}' for node ${site["ne-name"]} (ne-id: ${neId}) not found!`);
+      throw new Error(`Deploy-template "${templateName}" for node ${site["ne-name"]} (ne-id: ${neId}) not found!`);
     }
 
     const input = {
@@ -891,18 +967,45 @@ export class IntentHandler extends WebUI
       logger.error("Template: {}", templateName);
       logger.error("Input:    {}", IntentHandler.inspect(input));
 
-      throw new Error(`Deploy-template '${templateName}' issue for node ${this.deviceCache[neId]} (ne-id: ${neId}): FTL Error`);
+      throw new Error(`Deploy-template "${templateName}" issue for node ${this.deviceCache[neId]} (ne-id: ${neId}): FTL Error`);
     }
 
     try {
       return JSON.parse(siteObjectsJSON);
     } catch (exception) {
+      const len = siteObjectsJSON.length;
+
       logger.error("Exception parsing FTL-rendered JSON for node {} (ne-id: {}): {}", this.deviceCache[neId], neId, exception);
       logger.error("Template: {}", templateName);
       logger.error("Input:    {}", IntentHandler.inspect(input));
-      logger.error("Output:   {}", siteObjectsJSON);
 
-      throw new Error(`Deploy-template '${templateName}' issue for node ${this.deviceCache[neId]} (ne-id: ${neId}): JSON Error`);
+      if (len <= 10_000) {
+        logger.error("Output:   {}", siteObjectsJSON);
+      }
+      else if (len > 5_000_000) {
+        logger.error("Output:   omitted, {} KB", len >> 10);
+      }
+      else {
+        const CHUNK = 10_000;
+        const MAX_ARGS = 200;
+        const parts = [];
+        for (let pos = 0; pos < len; pos += CHUNK) {
+          parts.push(siteObjectsJSON.slice(pos, pos + CHUNK));
+        }
+        if (parts.length <= MAX_ARGS) {
+          const fmt = "{}".repeat(parts.length);
+          logger.error("Output:   {} KB\n" + fmt, len >> 10, ...parts);
+        } else {
+          logger.error("Output:   ~{} KB ({} fragments)", len >> 10, parts.length);
+          for (let i = 0; i < parts.length; i += MAX_ARGS) {
+            const batch = parts.slice(i, i + MAX_ARGS);
+            const pfx = i === 0 ? "Output:   " : "Output (cont): ";
+            logger.error(pfx + "{}".repeat(batch.length), ...batch);
+          }
+        }
+      }
+
+      throw new Error(`Deploy-template "${templateName}" issue for node ${this.deviceCache[neId]} (ne-id: ${neId}): JSON Error`);
     }
   }
 
@@ -925,7 +1028,7 @@ export class IntentHandler extends WebUI
       if (value === null) return "";
       if (typeof value === "boolean") return value ? "true" : "false";
       if (typeof value === "number") return String(value);
-      return `"${String(value).replace(/"/g, '\\"')}"`;
+      return `"${String(value).replace(/"/g, "\\\"")}"`;
     };
     const parseTargetPath = (target) => {
       if (typeof target !== "string" || target.trim() === "") return [];
@@ -1166,7 +1269,7 @@ export class IntentHandler extends WebUI
       if (value === null) return "";
       if (typeof value === "boolean") return value ? "true" : "false";
       if (typeof value === "number") return String(value);
-      return `"${String(value).replace(/"/g, '\\"')}"`;
+      return `"${String(value).replace(/"/g, "\\\"")}"`;
     };
     const parseTargetPath = (target) => {
       if (typeof target !== "string" || target.trim() === "") return [];
@@ -1390,27 +1493,26 @@ export class IntentHandler extends WebUI
 
   /**
    * Delete the corresponding path from configuration data (JSON).
-   * 
+   *
    * @param {object} data configuration to cleanup
    * @param {string} path subtree/leaf to be deleted
    * @param {string} separator
    */
-
-  deletePath(data, path, separator = '.') {
+  deletePath(data, path, separator = ".") {
     const [key, ...remains] = path.split(separator);
     if (data !== null && key in data) {
       if (remains.length > 0) {
         if (Array.isArray(data[key]))
           // list hit => iterate entries
           data[key].forEach(listEntry => this.deletePath(listEntry, remains.join(separator), separator));
-        else if (typeof data[key] === 'object')
+        else if (typeof data[key] === "object")
           // dict hit => follow the path
           this.deletePath(data[key], remains.join(separator), separator);
-      } else 
+      } else
         delete data[key]; // delete property
     }
   }
-  
+
   /**************************************************************************
    * Public methods of IntentHandler
    *
@@ -1462,9 +1564,9 @@ export class IntentHandler extends WebUI
             resourceProvider.getResource(templateName);
           } catch {
             if (neId in this.deviceCache)
-              contextualErrorJsonObj["Device-type unsupported"] = `Template '${templateName}' for node ${this.deviceCache[neId]} (ne-id: ${neId}) not found!`;
+              contextualErrorJsonObj["Device-type unsupported"] = `Template "${templateName}" for node ${this.deviceCache[neId]} (ne-id: ${neId}) not found!`;
             else
-              contextualErrorJsonObj["Device-type unsupported"] = `Template '${templateName}' for node ${neId} not found!`;
+              contextualErrorJsonObj["Device-type unsupported"] = `Template "${templateName}" for node ${neId} not found!`;
           }
         }
       }
@@ -1566,43 +1668,7 @@ export class IntentHandler extends WebUI
                 if (objects[objectName].config.ignoreChildren) {
                   const result = NSP.mdcGET(neId, objects[objectName].config.target+"?content=config");
                   if (result.success) {
-                    // Extract content from envelope
-                    // example: {"nokia-conf:port": [{"port-id": "1/1/1", ...}]} becomes [{"port-id": "1/1/1", ...}]
-                    let aCfg = Object.values(result.response)[0]; // actual config
-                    let iCfg = Object.values(desiredConfig)[0]; // intended config
-        
-                    // YANG list-entries are encoded as single-entry array (rfc8040, rfc8072)
-                    // Extract this single entry from the list
-                    // example: [{"port-id": "1/1/1", ...}] becomes {"port-id": "1/1/1", ...}
-        
-                    if (Array.isArray(aCfg)) {
-                      if (aCfg.length > 0) aCfg = aCfg[0]; else aCfg = {};
-                    }
-        
-                    if (Array.isArray(iCfg)) {
-                      if (iCfg.length > 0) iCfg = iCfg[0]; else iCfg = {};
-                    }
-        
-                    objects[objectName].config.ignoreChildren.forEach(path => {
-                      const keys = path.split('/');
-                      let source = aCfg;
-                      let target = iCfg;
-                  
-                      for (let i = 0; i < keys.length; i++) {
-                        const key = keys[i];
-                  
-                        if (key in source)
-                          if (i < keys.length - 1) {
-                            if (!(key in target))
-                              target[key] = {};
-                            source = source[key];
-                            target = target[key];
-                          } else {
-                            target[key] = source[key];
-                          }
-                        else break; // Stop processing this path
-                      }
-                    });
+                    this.mergePreservedSubtrees(neId, objects[objectName].config.target, desiredConfig, objects[objectName].config.ignoreChildren);
                   }
                   else if (result.errmsg === "Not Found") {
                     logger.info("Merge pre-approved misalignments skipped. Object not configured on device.");
@@ -1774,25 +1840,11 @@ export class IntentHandler extends WebUI
                 const desiredConfig = objects[objectName].config.value;
                 const deviceModelPath = objects[objectName].config.target;
 
-                // Extract content from envelope
-                // example: {"nokia-conf:port": [{"port-id": "1/1/1", ...}]} becomes [{"port-id": "1/1/1", ...}]
-                let aCfg = Object.values(result.response)[0]; // actual config
-                let iCfg = Object.values(desiredConfig)[0]; // intended config
-
-                // YANG list-entries are encoded as single-entry array (rfc8040, rfc8072)
-                // Extract this single entry from the list
-                // example: [{"port-id": "1/1/1", ...}] becomes {"port-id": "1/1/1", ...}
-
-                if (Array.isArray(aCfg)) {
-                  if (aCfg.length > 0) aCfg = aCfg[0]; else aCfg = {};
-                }
-
-                if (Array.isArray(iCfg)) {
-                  if (iCfg.length > 0) iCfg = iCfg[0]; else iCfg = {};
-                }                
+                let aCfg = this.unwrapRestconfBody(result.response);
+                let iCfg = this.unwrapRestconfBody(desiredConfig);
 
                 this.preAuditHook(neId, deviceModelPath, aCfg, iCfg);
-                this.compareConfig(neId, deviceModelPath, aCfg, iCfg, objects[objectName].config.operation, objects[objectName].config.ignoreChildren, auditReport, neId, '');
+                this.compareConfig(neId, deviceModelPath, aCfg, iCfg, objects[objectName].config.operation, objects[objectName].config.ignoreChildren, auditReport, neId, "");
               }
               else if (result.errmsg === "Not Found") {
                 // get failed, because path is not configured

--- a/templates/deviceSpecificICM/intent-type-resources/common/IntentHandlerBase.mjs
+++ b/templates/deviceSpecificICM/intent-type-resources/common/IntentHandlerBase.mjs
@@ -166,8 +166,8 @@ export class IntentHandlerBase extends WebUI
    */
 
   getNeIdFromTarget(target) {
-    const match = target.match(/ne-id='([^']+)'/);
-    return match ? match[1] : target.split('#')[1];
+    const match = target.match(/ne-id=\x27([^\x27]+)\x27/);
+    return match ? match[1] : target.split("#")[1];
   }
 
   /**
@@ -231,7 +231,7 @@ export class IntentHandlerBase extends WebUI
       return false;
 
     // split addr from prefix-len and validate prefix-len, if present
-    const [addr, prefix] = value.split('/');
+    const [addr, prefix] = value.split("/");
     if (prefix && (!/^\d{1,3}$/.test(prefix) || parseInt(prefix, 10) > 128))
       return false;
 
@@ -282,7 +282,7 @@ export class IntentHandlerBase extends WebUI
     }
 
     // Remove leading zeros from all parts
-    addr = addr.toLowerCase().split(":").map(part => part.replace(/^0+/, '') || '0').join(":");
+    addr = addr.toLowerCase().split(":").map(part => part.replace(/^0+/, "") || "0").join(":");
 
     // Identify the longest zero sequence for "::" compression
     const zeroSequences = addr.match(/(^|:)(0:)+(0$)?/g);
@@ -302,7 +302,7 @@ export class IntentHandlerBase extends WebUI
 
   assertEqual(actual, expected, message) {
     if (actual !== expected) {
-        throw new Error(`❌ Unit Testing Failed: ${message} | Expected: '${expected}', Got: '${actual}'`);
+        throw new Error(`❌ Unit Testing Failed: ${message} | Expected: "${expected}", Got: "${actual}"`);
     } else {
         logger.info(`✅ Passed: ${message}`);
     }
@@ -347,14 +347,102 @@ export class IntentHandlerBase extends WebUI
   
   getListKeys(neId, listPath) {
      // remove instance identifiers from path:
-    const path = listPath.replace(/=[^/]+/g, '');
+    const path = listPath.replace(/=[^/]+/g, "");
 
     if (!(path in this.mdcKeys)) {
       this.mdcKeys[path] = NSP.mdcListKeys(neId, path);
-      logger.info('list-key cache updated: {}', JSON.stringify(this.mdcKeys));
+      logger.info("list-key cache updated: {}", JSON.stringify(this.mdcKeys));
     }
 
     return this.mdcKeys[path];
+  }
+
+  /**
+   * Unwrap JSON body for intent audits and synchronize operations (merge / replace).
+   * Used for both:
+   *   - intended config (iCfg) — RESTCONF YANG-Patch `replace` request body
+   *   - actual config (aCfg) — RESTCONF `GET` data response body
+   *
+   * The return value is the config root used by recursive `compareConfig` or ignoreChildren merge.
+   *
+   * @param {object} body Single RESTCONF resource object (one module-qualified root key).
+   * @returns {*} Unwrapped root value (typically an object; containers skip step 2).
+   */
+  unwrapRestconfBody(body) {
+    // **Step 1:** Peel the outer wrapper: the last path segment appears once as the sole
+    // top-level property name (module-qualified root). Its value is the subtree for the target.
+    //
+    // Example: {"nokia-conf:port": [{"port-id": "1/1/1", ...}]} → [{"port-id": "1/1/1", ...}]
+
+    const config = Object.values(body)[0];
+
+    // **Step 2:** RFC 8040 / RFC 8072 JSON: a single list instance is a one-element array.
+    // Unwrap to the entry object for audits and merge. Empty array → {}.
+    //
+    // Example: [{"port-id": "1/1/1", ...}] → {"port-id": "1/1/1", ...}
+
+    if (Array.isArray(config)) {
+      if (config.length > 0)
+        return config[0];
+      else
+        return {};
+    }
+    return config;
+  }
+
+  /**
+   * Returns if the relativePath belongs to any ignored children. Used as audit helper to avoid
+   * reporting additional subtrees/attributes that are part of pre-approved misalignments.
+   *
+   * `neId` / `basePath` are currently unused. Added for future enhancements to properly support
+   * instance paths, while method needs to figure out list-keys correctly.
+   *
+   * Paths to ignore are taken from `this.ignoreChildren` (prefix match on `relativePath`).
+   *
+   * @param {string} neId              (reserved for future use)
+   * @param {string} basePath          (reserved for future use)
+   * @param {string} relativePath
+   * @returns {boolean}
+   */
+  isPreApproved(neId, basePath, relativePath) {
+    return this.ignoreChildren.some(path => relativePath.startsWith(path));
+  }
+
+  /**
+   * Merges subtrees from `actualConfig` (GET response) into `desiredConfig` (in-place mutation), to
+   * preserve nodal configuration for pre-approved misalignments (`this.ignoreChildren`).
+   *
+   * `neId` / `deviceModelPath` are currently unused. Added for future enhancements to properly support
+   * instance paths, while method needs to figure out list-keys correctly.
+   *
+   * Unwraps both envelopes, copies paths segment-by-segment (same as 4.2.1).
+   *
+   * @param {string} neId              (reserved for future use)
+   * @param {string} deviceModelPath   (reserved for future use)
+   * @param {object} desiredConfig     RESTCONF envelope for the intent (replace payload)
+   * @param {object} actualConfig      Configuration response payload (RESTCONF GET)
+   */
+  mergePreservedSubtrees(neId, deviceModelPath, desiredConfig, actualConfig) {
+    const aCfg = this.unwrapRestconfBody(actualConfig);
+    const iCfg = this.unwrapRestconfBody(desiredConfig);
+    this.ignoreChildren.forEach(path => {
+      const keys = path.split("/");
+      let source = aCfg;
+      let target = iCfg;
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        if (key in source)
+          if (i < keys.length - 1) {
+            if (!(key in target))
+              target[key] = {};
+            source = source[key];
+            target = target[key];
+          } else {
+            target[key] = source[key];
+          }
+        else break;
+      }
+    });
   }
 
   /**
@@ -368,7 +456,7 @@ export class IntentHandlerBase extends WebUI
    * @param {string} obj object reference used for report
    * @param {string} path used to build up relative path (recursive)
    */
-
+  
   compareConfig(neId, basePath, aCfg, iCfg, auditReport, obj, path) {
     const startTS = Date.now();
     logger.debug("IntentHandler::compareConfig(neId={}, basePath={}, path={})", neId, basePath, path);
@@ -443,33 +531,21 @@ export class IntentHandlerBase extends WebUI
 
     for (const key in aCfg) {
       if (!(key in iCfg)) {
-        // Possibility to exclude children (pre-approved misalignments) that match the list provided.
-        // Current Restrictions:
-        //  (1) Intent config (icfg) must not contain attributes that match the ignored children 
-        //  (2) Intent config (icfg) must contain the direct parents of the ignored children
+        const relativePath = path + key;        
+        if (!this.isPreApproved(neId, basePath, relativePath)) {
 
-        let found = "";
-        const aKey = path+key;
-        for (const idx in this.ignoreChildren) {
-          if (aKey.startsWith(this.ignoreChildren[idx])) {
-            found = this.ignoreChildren[idx];
-            break;
-          }
-        }
-
-        if (!found) {
           if (aCfg[key] instanceof Object) {
             // mismatch: undesired list/container
 
             const aVal = JSON.stringify(aCfg[key]);
             if ((aVal === "{}") || (aVal === "[]") || (aVal === "[null]"))
-              auditReport.addMisAlignedAttribute(new MisAlignedAttribute("/"+basePath+"/"+aKey, null, aVal, obj));
+              auditReport.addMisAlignedAttribute(new MisAlignedAttribute("/"+basePath+"/"+relativePath, null, aVal, obj));
             else
               // undesired object: is-configured=true, is-undesired=default(true)
-              auditReport.addMisAlignedObject(new MisAlignedObject("/"+basePath+"/"+aKey, true, neId, true));
+              auditReport.addMisAlignedObject(new MisAlignedObject("/"+basePath+"/"+relativePath, true, neId, true));
           } else {
             // mismatch: additional leaf
-            auditReport.addMisAlignedAttribute(new MisAlignedAttribute("/"+basePath+"/"+aKey, null, aCfg[key].toString(), obj));
+            auditReport.addMisAlignedAttribute(new MisAlignedAttribute("/"+basePath+"/"+relativePath, null, aCfg[key].toString(), obj));
           }
         }
       }
@@ -494,14 +570,14 @@ export class IntentHandlerBase extends WebUI
     // handle YANG lists, leaf-lists
     if (Array.isArray(cfg)) {
       const cleanedArray = cfg.map(v => this.cleanupConfig(v));
-      return cleanedArray.every(v => v === null) ? cleanedArray : cleanedArray.filter(v => typeof v !== 'object' || Object.entries(v).length > 0);      
+      return cleanedArray.every(v => v === null) ? cleanedArray : cleanedArray.filter(v => typeof v !== "object" || Object.entries(v).length > 0);      
     }
 
     // handle YANG containers
-    if (cfg && typeof cfg === 'object')
+    if (cfg && typeof cfg === "object")
       return Object.fromEntries(Object.entries(cfg)
         .map(([k, v]) => [k, this.cleanupConfig(v)])
-        .filter(([_, v]) => typeof v !== 'object' || Object.entries(v).length > 0)
+        .filter(([_, v]) => typeof v !== "object" || Object.entries(v).length > 0)
       );
 
     // handle YANG leafs (primitive types)
@@ -510,23 +586,23 @@ export class IntentHandlerBase extends WebUI
 
   /**
    * Delete the corresponding path from configuration data (JSON).
-   * 
+   *
    * @param {object} data configuration to cleanup
    * @param {string} path subtree/leaf to be deleted
    * @param {string} separator
    */
-
-  deletePath(data, path, separator = '.') {
+  
+  deletePath(data, path, separator = ".") {
     const [key, ...remains] = path.split(separator);
     if (data !== null && key in data) {
       if (remains.length > 0) {
         if (Array.isArray(data[key]))
           // list hit => iterate entries
           data[key].forEach(listEntry => this.deletePath(listEntry, remains.join(separator), separator));
-        else if (typeof data[key] === 'object')
-          // dict hit => follow the path
+        else if (typeof data[key] === "object")
+          // dict hit => follow the path (recurse)         
           this.deletePath(data[key], remains.join(separator), separator);
-      } else 
+      } else
         delete data[key]; // delete property
     }
   }
@@ -629,43 +705,7 @@ export class IntentHandlerBase extends WebUI
         if (this.ignoreChildren.length > 0) {
           const result = NSP.mdcGET(neId, deviceModelPath+"?content=config");
           if (result.success) {
-            // Extract content from envelope
-            // example: {"nokia-conf:port": [{"port-id": "1/1/1", ...}]} becomes [{"port-id": "1/1/1", ...}]
-            let aCfg = Object.values(result.response)[0]; // actual config
-            let iCfg = Object.values(desiredConfig)[0]; // intended config
-
-            // YANG list-entries are encoded as single-entry array (rfc8040, rfc8072)
-            // Extract this single entry from the list
-            // example: [{"port-id": "1/1/1", ...}] becomes {"port-id": "1/1/1", ...}
-
-            if (Array.isArray(aCfg)) {
-              if (aCfg.length > 0) aCfg = aCfg[0]; else aCfg = {};
-            }
-
-            if (Array.isArray(iCfg)) {
-              if (iCfg.length > 0) iCfg = iCfg[0]; else iCfg = {};
-            }
-
-            this.ignoreChildren.forEach(path => {
-              const keys = path.split('/');
-              let source = aCfg;
-              let target = iCfg;
-          
-              for (let i = 0; i < keys.length; i++) {
-                const key = keys[i];
-          
-                if (key in source)
-                  if (i < keys.length - 1) {
-                    if (!(key in target))
-                      target[key] = {};
-                    source = source[key];
-                    target = target[key];
-                  } else {
-                    target[key] = source[key];
-                  }
-                else break; // Stop processing this path
-              }
-            });
+            this.mergePreservedSubtrees(neId, deviceModelPath, desiredConfig, result.response);
           }
           else if (result.errmsg === "Not Found") {
             logger.info("Merge pre-approved misalignments skipped. Object not configured on device.");
@@ -762,25 +802,11 @@ export class IntentHandlerBase extends WebUI
     const result = NSP.mdcGET(neId, deviceModelPath+"?content=config");
     if (result.success) {
       if (state === "active") {
-        // Extract content from envelope
-        // example: {"nokia-conf:port": [{"port-id": "1/1/1", ...}]} becomes [{"port-id": "1/1/1", ...}]
-        let aCfg = Object.values(result.response)[0]; // actual config
-        let iCfg = Object.values(desiredConfig)[0]; // intended config
+        let aCfg = this.unwrapRestconfBody(result.response);
+        let iCfg = this.unwrapRestconfBody(desiredConfig);
 
-        // YANG list-entries are encoded as single-entry array (rfc8040, rfc8072)
-        // Extract this single entry from the list
-        // example: [{"port-id": "1/1/1", ...}] becomes {"port-id": "1/1/1", ...}
-
-        if (Array.isArray(aCfg)) {
-          if (aCfg.length > 0) aCfg = aCfg[0]; else aCfg = {};
-        }
-
-        if (Array.isArray(iCfg)) {
-          if (iCfg.length > 0) iCfg = iCfg[0]; else iCfg = {};
-        }
-  
         this.preAuditHook(neId, deviceModelPath, aCfg, iCfg);
-        this.compareConfig(neId, deviceModelPath, aCfg, iCfg, auditReport, neId, '');
+        this.compareConfig(neId, deviceModelPath, aCfg, iCfg, auditReport, neId, "");
       } else {
         // undesired objects: is-configured=true, is-undesired=true
         auditReport.addMisAlignedObject(new MisAlignedObject("/"+deviceModelPath, true, neId, true));
@@ -824,7 +850,7 @@ export class IntentHandlerBase extends WebUI
 
     logger.info("IntentHandler::getStateAttributes() in state {}", state);
 
-    const stateXML = '<state-report xmlns="http://www.nokia.com/management-solutions/ibn" />';
+    const stateXML = "<state-report xmlns=\"http://www.nokia.com/management-solutions/ibn\" />";
     
     const duration = Date.now()-startTS;
     logger.info("IntentHandler::getStateAttributes() finished within {} ms", duration|0);
@@ -869,7 +895,7 @@ export class IntentHandlerBase extends WebUI
       }
 
       if (this.ignoreChildren.length > 0) {
-        this.ignoreChildren.forEach(path => this.deletePath(config, path, '/'));
+        this.ignoreChildren.forEach(path => this.deletePath(config, path, "/"));
         config = this.cleanupConfig(config);
       }
 


### PR DESCRIPTION
Template Improvement (Developer Experience):
* Abstract/Fixed intent-types: FTL JSON parse diagnostics for extra-long rendered output using multi-arg `logger.error` with at most 10_000 char fragments
* Rendered output omitted when longer than 5 MB. Only summary line will be generated (OpenSearch / VS Code Server Logs)

Template Refactoring:
* Quote/style normalization in ICM `IntentHandlerBase.mjs` and abstract `IntentHandler.mjs`
* Added `unwrapRestconfBody()` for common RESTCONF envelope handling
* Added `mergePreservedSubtrees()` keeping existing behavior for merging actual config subtrees based on pre-approved misalignments aka ignoreChildren
* Added `isPreApproved()` keeping existing behavior to ignore additional subtrees in the actual config during audits based on pre-approved misalignments aka ignoreChildren